### PR TITLE
change clone link (?)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This version of the plugin is adapted from the [console plugin](https://github.c
 ## Install
 Navigate to the `data/plugins` folder and run the following command:
 ```bash
-git clone https://github.com/franko/console
+git clone https://github.com/lite-xl/console
 ```
 Alternatively the `init.lua` file can be renamed `console.lua` and dropped in
 the `data/plugins` folder.


### PR DESCRIPTION
https://github.com/lite-xl/console/blob/102129c6e4da0cd63a4c5dd47ea41a01def0e943/README.md?plain=1#L11

The repository which you can clone to get the plugin (franko/console) redirects me to this repo (lite-xl/console), so I supposed it doesn't make a difference and replaced franko/console with this repo's link.

Just considered it an important change given that it might confuse people, even though it's little.