### PR TITLE
Fix command execution on windows.

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -139,7 +139,7 @@ function console.run(opt)
   local function thread()
     local command
     if PLATFORM == "Windows" then
-      command = { "cmd", "/c", string.format("(%s) 2>&1", opt.command) }
+      command = string.format("cmd /c (%s) 2>&1", opt.command)
     else
       command = { "bash", "-c", "--", string.format("(%s) 2>&1", opt.command) }
     end


### PR DESCRIPTION
Opened this PR for future reference so it can serve as a reminder of why a process command packed as a table could cause issues on windows.

As discussed on discord the new changes to the lite-xl process api to properly handle argument escaping on windows introduced on https://github.com/lite-xl/lite-xl/pull/1132, when passing the command as a table it double quotes all arguments and also parenthesized statements like `cmd /c (echo hello)` which results in `"cmd" "/c" "(echo hello)"`. This causes batch to error out as it improperly interprets "(echo hello)" as a whole command instead of a group of statements.

To fix the issue with newer process api one would need to use a plain string instead of a table to disable the quoting mechanism when inappropriate.