### PR TITLE
Some things to make lite-xl console plugin better

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -6,6 +6,7 @@ local common = require "core.common"
 local config = require "core.config"
 local style = require "core.style"
 local View = require "core.view"
+local docview = require "core.docview"
 
 local console = {}
 
@@ -27,6 +28,7 @@ config.plugins.console = common.merge({
   size = 250 * SCALE,
   max_lines = 200,
   autoscroll = true,
+  console_place = "rootview"
   config_spec = {
     name = "Console",
     {
@@ -62,6 +64,18 @@ config.plugins.console = common.merge({
       path = "autoscroll",
       type = "toggle",
       default = true,
+    },
+    {
+      label = "Place",
+      description = "Place of console output.",
+      path = "console_place",
+      type = "selection",
+      default = "rootview",
+      values =
+      {
+          {"Root View", "rootview"},
+          {"Document View", "doview"},
+      }
     }
   }
 }, config.plugins.console)
@@ -368,8 +382,14 @@ end
 function main.start_console()
   -- init static bottom-of-screen console
   main.view = ConsoleView()
-  local node = core.root_view.root_node:get_node_for_view(core.command_view)
-  node:split("up", main.view, {y = true}, true)
+
+  if config.plugins.console.console_place == "rootview" then
+    local node = core.root_view.root_node:get_node_for_view(core.command_view)
+    node:split("up", main.view, {y = true}, true)
+  else
+    local node = core.root_view.root_node:get_node_for_view(core.active_view)
+    node:split("down", main.view, {y = true}, true)
+  end
 
   function main.view:update(...)
     local dest = visible and self.target_size or 0

--- a/init.lua
+++ b/init.lua
@@ -311,8 +311,8 @@ function ConsoleView:on_mouse_pressed(...)
     end
     core.try(function()
       core.root_view:open_doc(core.open_doc(resolved_file))
-      line = tonumber(line) or 1
-      col = tonumber(col) or 1
+      line = tonumber(string.match(line, "%d+")) or 1
+      col = tonumber(string.match(col, "%d+")) or 1
       core.add_thread(function()
         core.active_view.doc:set_selection(line, col)
       end)

--- a/init.lua
+++ b/init.lua
@@ -84,13 +84,21 @@ function console.clear()
   output = { { text = "", time = 0 } }
 end
 
+function console.toggle()
+  visible = not visible
+end
+function console.close()
+  visible = false
+end
+function console.isVisible()
+  return visible
+end
 
 local function write_file(filename, text)
   local fp = io.open(filename, "w")
   fp:write(text)
   fp:close()
 end
-
 
 local function lines(text)
   return (text .. "\n"):gmatch("(.-)\n")


### PR DESCRIPTION
- Setting for console place: Root View or Document View
- Expose console visible actions, to hide, toggle or view if console is visible
- Get only first number in line of error or warning messages on console plugin


<details>
  <summary>Example with console open on document view only</summary>

![image](https://github.com/rxi/console/assets/5851851/6e877f22-7c6c-45ab-8e87-60196d3bebb9)


</details>
